### PR TITLE
move webpack to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "postcss": "^7.0.13",
     "postcss-extract-styles": "^1.2.0",
     "postcss-prefix-selector": "^1.6.0",
-    "webpack": "^4.28.4",
     "webpack-sources": "^1.3.0"
   },
   "devDependencies": {
@@ -50,6 +49,7 @@
     "tslint": "^5.12.1",
     "tslint-config-yoshi-base": "^3.22.5",
     "typescript": "^3.2.4",
+    "webpack": "^4.28.4",
     "webpack-merge": "^4.2.1"
   },
   "publishConfig": {


### PR DESCRIPTION
Due to a bug in terser@4.0.1 (that is a dependency of webpack)
We've discovered that this package has a dependency on webpack.