### PR TITLE
Add symlinks support

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
 import {RawSource, ReplaceSource} from 'webpack-sources';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as postcss from 'postcss';
 import * as extractStyles from 'postcss-extract-styles';
@@ -43,7 +44,7 @@ class TPAStylePlugin {
   private replaceRuntimeModule(compiler) {
     const runtimePath = path.resolve(__dirname, '../../runtime.js');
     const nmrp = new webpack.NormalModuleReplacementPlugin(/runtime\.js$/, resource => {
-      if (resource.resource !== runtimePath) {
+      if (fs.realpathSync(resource.resource) !== runtimePath) {
         return;
       }
 


### PR DESCRIPTION
When we test [yoshi's](https://github.com/wix/yoshi) templates we symlink our modules the replacement of the fake and the real `main`s than fails.

As a result, we don't see styles on the page (we get the fake entry...).

This PR will support this edge case even if the `resource.resource` is symlinked to somewhere else.