### PR TITLE
a fix to a bug in wix ui tpa and stylable mixing

### DIFF
--- a/src/runtime/cssFunctions.ts
+++ b/src/runtime/cssFunctions.ts
@@ -58,6 +58,8 @@ export const cssFunctions = {
       };
     } else if (tpaParams.fonts[font]) {
       fontValue = tpaParams.fonts[font];
+    } else if (typeof font === 'string' && font.indexOf('font:') === 0) {
+      return font.slice(5, font.length - 1);
     } else {
       return escapeHtml(font);
     }

--- a/tests/units/cssFunctions.spec.ts
+++ b/tests/units/cssFunctions.spec.ts
@@ -126,6 +126,22 @@ describe('cssFunctions', () => {
       ).toBe('normal variant bold 20px/1em family,family2');
     });
 
+    it('should support font css definition', () => {
+      const font = {
+        size: '10',
+        lineHeight: '1.4',
+        style: 'italic',
+        family: ['family', 'family2;'],
+        weight: 'bold',
+        variant: 'variant',
+      };
+      expect(
+        cssFunctions.font(`font:normal variant bold 20px/1em family,family2;`, {
+          fonts: {['Body-M']: font},
+        } as any)
+      ).toBe('normal variant bold 20px/1em family,family2');
+    });
+
     it('should return given font', () => {
       expect(cssFunctions.font(`unknown-font<xss>`, {fonts: {}} as any)).toBe(`unknown-font&lt;xss&gt;`);
     });


### PR DESCRIPTION
there is a bug that only happening in stylable mixin and wix-ui-tpa
for example if you use them with this definition

```
-st-mixin: TPAText(
    MainTextFont '"fallback(--someVar, font({theme: 'Body-M', size: '16px', lineHeight: '1.33em'}))"'
);
```
then the fallback inside is messed up