### PR TITLE
Using seperate entry for standalone flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/src/runtime/fakeMain.ts
+++ b/src/runtime/fakeMain.ts
@@ -1,5 +1,4 @@
-import {IStyles} from './types';
-import {IOptions} from './main';
+import {IStyles, IOptions} from './types';
 
 exports.getProcessedCss = function getProcessedCss(styles: IStyles, options: IOptions): string {
   return '';

--- a/src/runtime/generateTPAParams.ts
+++ b/src/runtime/generateTPAParams.ts
@@ -1,9 +1,8 @@
 import {pickBy} from './utils/utils';
 import {wixStylesFontUtils} from './utils/wixStyleFontUtils';
 import {wixStylesColorUtils} from './utils/wixStylesColorUtils';
-import {IOptions} from './main';
 import {IS_RTL_PARAM} from './constants';
-import {ISiteColor, ISiteTextPreset, IStyleFont, IStyleParams} from './types';
+import {IOptions, ISiteColor, ISiteTextPreset, IStyleFont, IStyleParams} from './types';
 
 export interface ITPAParams {
   colors: {[index: string]: {value: string}};

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,26 +1,7 @@
-import {generateTPAParams} from './generateTPAParams';
-import {getProcessor} from './processor';
-import {cssFunctions} from './cssFunctions';
-import {Plugins} from './plugins';
-import {IInjectedData, IStyles} from './types';
-
-function escapeRegExp(str) {
-  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
-}
-
-const plugins = new Plugins();
-Object.keys(cssFunctions).forEach(funcName => plugins.addCssFunction(funcName, cssFunctions[funcName]));
-
-export interface IOptions {
-  isRTL: boolean;
-  prefixSelector: string;
-  strictMode: boolean;
-}
-
+import {IOptions, IInjectedData, IStyles} from './types';
+import {getProcessedCssWithConfig, getStaticCssWithConfig} from './standalone';
 export type IGetProcessedCssFn = typeof getProcessedCss;
-export type IGetProcessedCssWithConfigFn = typeof getProcessedCssWithConfig;
 export type IGetStaticCssFn = typeof getStaticCss;
-export type IGetStaticCssWithConfigFn = typeof getStaticCssWithConfig;
 
 export interface CssConfig {
   cssVars: {[key: string]: string};
@@ -29,12 +10,6 @@ export interface CssConfig {
   staticCss: string;
   compilationHash: string;
 }
-
-const defaultOptions = {
-  isRTL: false,
-  strictMode: true,
-};
-
 export function getProcessedCss(styles: IStyles, options?: Partial<IOptions>): string {
   const injectedData = '__COMPILATION_HASH__INJECTED_DATA_PLACEHOLDER' as any;
 
@@ -44,49 +19,6 @@ export function getProcessedCss(styles: IStyles, options?: Partial<IOptions>): s
   };
 
   return getProcessedCssWithConfig(processedCssConfig, styles, options);
-}
-
-export function getProcessedCssWithConfig(
-  processedCssConfig: CssConfig,
-  {siteColors, siteTextPresets, styleParams}: IStyles,
-  options?: Partial<IOptions>
-): string {
-  options = {...defaultOptions, ...(options || {})};
-
-  if (!processedCssConfig.css) {
-    return '';
-  }
-
-  const prefixedCss = processedCssConfig.css.replace(
-    new RegExp(processedCssConfig.compilationHash, 'g'),
-    options.prefixSelector ? `${options.prefixSelector}` : ''
-  );
-
-  const tpaParams = generateTPAParams(siteColors, siteTextPresets, styleParams, options);
-
-  const processor = getProcessor({cssVars: processedCssConfig.cssVars, plugins});
-
-  return processedCssConfig.customSyntaxStrs.reduce((processedContent, part) => {
-    let newValue;
-    try {
-      newValue = processor.process({part, tpaParams});
-    } catch (e) {
-      if (options.strictMode) {
-        throw e;
-      } else {
-        newValue = '';
-      }
-    }
-    return processedContent.replace(new RegExp(escapeRegExp(part), 'g'), newValue);
-  }, prefixedCss);
-}
-
-export function getStaticCssWithConfig(staticCssConfig: CssConfig, {prefixSelector} = {prefixSelector: ''}) {
-  const prefixedCss = (staticCssConfig.staticCss || '').replace(
-    new RegExp(staticCssConfig.compilationHash, 'g'),
-    prefixSelector
-  );
-  return prefixedCss;
 }
 
 export function getStaticCss(options?: Pick<IOptions, 'prefixSelector'>) {

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -3,13 +3,6 @@ import {getProcessedCssWithConfig, getStaticCssWithConfig} from './standalone';
 export type IGetProcessedCssFn = typeof getProcessedCss;
 export type IGetStaticCssFn = typeof getStaticCss;
 
-export interface CssConfig {
-  cssVars: {[key: string]: string};
-  customSyntaxStrs: string[];
-  css: string;
-  staticCss: string;
-  compilationHash: string;
-}
 export function getProcessedCss(styles: IStyles, options?: Partial<IOptions>): string {
   const injectedData = '__COMPILATION_HASH__INJECTED_DATA_PLACEHOLDER' as any;
 

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -1,0 +1,71 @@
+import {generateTPAParams} from './generateTPAParams';
+import {getProcessor} from './processor';
+import {cssFunctions} from './cssFunctions';
+import {Plugins} from './plugins';
+import {IOptions, IStyles} from './types';
+
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+}
+
+const plugins = new Plugins();
+Object.keys(cssFunctions).forEach(funcName => plugins.addCssFunction(funcName, cssFunctions[funcName]));
+
+export type IGetProcessedCssWithConfigFn = typeof getProcessedCssWithConfig;
+export type IGetStaticCssWithConfigFn = typeof getStaticCssWithConfig;
+
+export interface CssConfig {
+  cssVars: {[key: string]: string};
+  customSyntaxStrs: string[];
+  css: string;
+  staticCss: string;
+  compilationHash: string;
+}
+
+const defaultOptions = {
+  isRTL: false,
+  strictMode: true,
+};
+
+export function getProcessedCssWithConfig(
+  processedCssConfig: CssConfig,
+  {siteColors, siteTextPresets, styleParams}: IStyles,
+  options?: Partial<IOptions>
+): string {
+  options = {...defaultOptions, ...(options || {})};
+
+  if (!processedCssConfig.css) {
+    return '';
+  }
+
+  const prefixedCss = processedCssConfig.css.replace(
+    new RegExp(processedCssConfig.compilationHash, 'g'),
+    options.prefixSelector ? `${options.prefixSelector}` : ''
+  );
+
+  const tpaParams = generateTPAParams(siteColors, siteTextPresets, styleParams, options);
+
+  const processor = getProcessor({cssVars: processedCssConfig.cssVars, plugins});
+
+  return processedCssConfig.customSyntaxStrs.reduce((processedContent, part) => {
+    let newValue;
+    try {
+      newValue = processor.process({part, tpaParams});
+    } catch (e) {
+      if (options.strictMode) {
+        throw e;
+      } else {
+        newValue = '';
+      }
+    }
+    return processedContent.replace(new RegExp(escapeRegExp(part), 'g'), newValue);
+  }, prefixedCss);
+}
+
+export function getStaticCssWithConfig(staticCssConfig: CssConfig, {prefixSelector} = {prefixSelector: ''}) {
+  const prefixedCss = (staticCssConfig.staticCss || '').replace(
+    new RegExp(staticCssConfig.compilationHash, 'g'),
+    prefixSelector
+  );
+  return prefixedCss;
+}

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -4,7 +4,7 @@ import {cssFunctions} from './cssFunctions';
 import {Plugins} from './plugins';
 import {IOptions, IStyles} from './types';
 
-function escapeRegExp(str) {
+function escapeRegExp(str: string) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -70,3 +70,9 @@ export interface ITextPreset {
   value: string;
   weight: string;
 }
+
+export interface IOptions {
+  isRTL: boolean;
+  prefixSelector: string;
+  strictMode: boolean;
+}

--- a/standalone.d.ts
+++ b/standalone.d.ts
@@ -1,0 +1,19 @@
+import {IOptions, IStyles} from './dist/runtime/types';
+import {CssConfig as ICssConfig} from './dist/runtime/standalone';
+
+export type CssConfig = ICssConfig;
+
+export declare function getProcessedCssWithConfig(
+  processedCssConfig: CssConfig,
+  {siteColors, siteTextPresets, styleParams}: IStyles,
+  options?: Partial<IOptions>
+): string;
+
+export declare function getStaticCssWithConfig(
+  staticCssConfig: CssConfig,
+  {
+    prefixSelector,
+  }?: {
+    prefixSelector: string;
+  }
+): string;

--- a/standalone.js
+++ b/standalone.js
@@ -1,0 +1,1 @@
+export {getProcessedCssWithConfig, getStaticCssWithConfig} from './dist/runtime/standalone';

--- a/tests/runtime-size.spec.ts
+++ b/tests/runtime-size.spec.ts
@@ -10,7 +10,7 @@ describe('runtime size', () => {
     await clearDir(outputDirPath);
   });
 
-  it('should throw when lib size exceeds 26kb', () => {
+  it('should throw when lib size exceeds 27kb', () => {
     return runWebpack({
       output: {
         path: path.resolve(outputDirPath),

--- a/tests/runtime-standalone.spec.ts
+++ b/tests/runtime-standalone.spec.ts
@@ -1,13 +1,8 @@
 import * as path from 'path';
 import {clearDir} from './helpers/clear-dir';
 import {runWebpack} from './helpers/run-webpack';
-import {
-  IGetProcessedCssFn,
-  IGetProcessedCssWithConfigFn,
-  IGetStaticCssFn,
-  IGetStaticCssWithConfigFn,
-  CssConfig,
-} from '../src/runtime/main';
+import {IGetProcessedCssFn, IGetStaticCssFn} from '../src/runtime/main';
+import {getProcessedCssWithConfig, getStaticCssWithConfig, CssConfig} from '../src/runtime/standalone';
 import {siteColors} from './fixtures/siteColors';
 import {siteTextPresets} from './fixtures/siteTextPresets';
 import {styleParams} from './fixtures/styleParams';
@@ -15,11 +10,7 @@ import {styleParams} from './fixtures/styleParams';
 describe('runtime standalone', () => {
   const outputDirPath = path.resolve(__dirname, './output/runtime-standalone');
   const entryName = 'app';
-  let getProcessedCss: IGetProcessedCssFn,
-    getStaticCss: IGetStaticCssFn,
-    getProcessedCssWithConfig: IGetProcessedCssWithConfigFn,
-    getStaticCssWithConfig: IGetStaticCssWithConfigFn,
-    cssConfig: CssConfig;
+  let getProcessedCss: IGetProcessedCssFn, getStaticCss: IGetStaticCssFn, cssConfig: CssConfig;
 
   beforeAll(async () => {
     await clearDir(outputDirPath);
@@ -39,8 +30,6 @@ describe('runtime standalone', () => {
 
     getProcessedCss = runtime.getProcessedCss;
     getStaticCss = runtime.getStaticCss;
-    getStaticCssWithConfig = runtime.getStaticCssWithConfig;
-    getProcessedCssWithConfig = runtime.getProcessedCssWithConfig;
   });
 
   it('should generate identical dynamic css as injected config', () => {


### PR DESCRIPTION
The plugin changes `tpa-style-webpack-plugin/runtime` file during the build time to `tpa-style-webpack-plugin/dist/runtime/main`. I didn't want to add same logic for standalone flow, so I've created a new entry file.

This PR allows to: `import {getProcessedCssWithConfig, getStaticCssWithConfig} from 'tpa-style-webpack-plugin/standalone';`.