### PR TITLE
A11y smart contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ addStyles(dynamicCss, 'tag-id');
     font: "font(--my-font2)";                                               /* will use the overridden default unless it was defined in settings  */
     border-width: "unit(--var-from-settings, px)";                          /* will produce border-width: 42px */
     color: "fallback(color(--var-from-settings), color(color-8))";          /* will return the first none falsy value from left to right */
+    background-color: "smartContrast(color(--base-color), color(--contrast-color))"; /* given a base color and a suggested contrast color, returns the given contrast color if it's A11Y compliant or a lightened/darkened color that will comply */
 }
 ```
 

--- a/src/runtime/cssFunctions.ts
+++ b/src/runtime/cssFunctions.ts
@@ -1,4 +1,4 @@
-import {TinyColor, isReadable, readability} from '@ctrl/tinycolor';
+import {TinyColor, isReadable} from '@ctrl/tinycolor';
 import {ITPAParams} from './generateTPAParams';
 import {escapeHtml, isJsonLike, parseJson} from './utils/utils';
 import {wixStylesFontUtils} from './utils/wixStyleFontUtils';

--- a/tests/__snapshots__/extract-styles.spec.ts.snap
+++ b/tests/__snapshots__/extract-styles.spec.ts.snap
@@ -108,7 +108,10 @@ exports[`Extract Styles should contain only TPA styles: dynamic-css 1`] = `
  .lighten {rule1: rgb(77, 255, 77);}
  .nested-functions-with-multiple-functions-params {--var: #F3F3F3; color: rgba(255, 255, 255, 0.5)}
  .font-without-font-family {font: italic normal bold 10px/2em futura-lt-w01-book,sans-serif;text-decoration: };
- .font-with-multiple-font-family {font: italic normal bold 10px/2em futura-lt-w01-book,sans-serif;text-decoration: };"
+ .font-with-multiple-font-family {font: italic normal bold 10px/2em futura-lt-w01-book,sans-serif;text-decoration: };
+ .smart-contrast-good {background-color: rgb(0, 0, 0);}
+ .smart-contrast-bad {background-color: rgb(0, 0, 0);}
+ .smart-contrast-bad-flipped {background-color: rgb(0, 0, 0);}"
 `;
 
 exports[`Extract Styles should extract out TPA styles from regular css: static-css 1`] = `

--- a/tests/fixtures/styles2.css
+++ b/tests/fixtures/styles2.css
@@ -93,6 +93,8 @@
 
 .font-without-font-family {font: "font(--bodyText)"};
 
+.font-with-multiple-font-family {font: "font(--bodyText)"};
+
 .smart-contrast-good {background-color: "smartContrast(color(--fgColor), color(--darkenedBGColor))";}
 
 .smart-contrast-bad {background-color: "smartContrast(color(--fgColor), color(--badBGColor))";}

--- a/tests/fixtures/styles2.css
+++ b/tests/fixtures/styles2.css
@@ -93,4 +93,8 @@
 
 .font-without-font-family {font: "font(--bodyText)"};
 
-.font-with-multiple-font-family {font: "font(--bodyText)"};
+.smart-contrast-good {background-color: "smartContrast(color(--fgColor), color(--darkenedBGColor))";}
+
+.smart-contrast-bad {background-color: "smartContrast(color(--fgColor), color(--badBGColor))";}
+
+.smart-contrast-bad-flipped {background-color: "smartContrast(color(--badBGColor), color(--fgColor))";}

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -646,6 +646,33 @@ describe('runtime', () => {
     });
   });
 
+  describe('smartContrast', () => {
+    const fgColor = '#DFF0D8';
+    const badBGColor = '#468847';
+    const lightenedFGColor = 'rgb(255, 255, 255)';
+    const darkenedBGColor = 'rgb(61, 119, 62)';
+
+    it('should return a11y compliant colors', () => {
+      const newStyleParams = clonedWith(styleParams, {
+        numbers: {},
+        colors: {
+          fgColor: {value: fgColor},
+          badBGColor: {value: badBGColor},
+          lightenedFGColor: {value: lightenedFGColor},
+          darkenedBGColor: {value: darkenedBGColor},
+        },
+        fonts: {},
+      });
+      const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {});
+      const acceptGivenGoodColor = `.smart-contrast-good {background-color: ${darkenedBGColor};}`;
+      expect(css).toContain(acceptGivenGoodColor);
+      const adjustGivenBadColor = `.smart-contrast-bad {background-color: ${darkenedBGColor};}`;
+      expect(css).toContain(adjustGivenBadColor);
+      const adjustFlippedColors = `.smart-contrast-bad-flipped {background-color: ${lightenedFGColor};}`;
+      expect(css).toContain(adjustFlippedColors);
+    });
+  });
+
   describe('Options', () => {
     describe('isRTL', () => {
       it('should support LTR', () => {

--- a/tests/units/cssFunctions.spec.ts
+++ b/tests/units/cssFunctions.spec.ts
@@ -1,5 +1,9 @@
 import {cssFunctions} from '../../src/runtime/cssFunctions';
 import {IS_RTL_PARAM} from '../../src/runtime/constants';
+import {clonedWith} from '../helpers/cloned-with';
+import {styleParams} from '../fixtures/styleParams';
+import {siteColors} from '../fixtures/siteColors';
+import {siteTextPresets} from '../fixtures/siteTextPresets';
 
 describe('cssFunctions', () => {
   describe('join', () => {
@@ -252,6 +256,25 @@ describe('cssFunctions', () => {
           );
         });
       });
+    });
+  });
+
+  describe('smartContrast', () => {
+    const textColor = '#DFF0D8';
+    const lightenedColor = 'rgb(255, 255, 255)';
+    const badBgColor = '#468847';
+    const darkenedColor = 'rgb(61, 119, 62)';
+
+    it('should return darkened color when contrast to low', () => {
+      expect(cssFunctions.smartContrast(textColor, badBgColor)).toBe(darkenedColor);
+    });
+
+    it('should return lightened color when contrast to low', () => {
+      expect(cssFunctions.smartContrast(badBgColor, textColor)).toBe(lightenedColor);
+    });
+
+    it('should return same color when good contrast', () => {
+      expect(cssFunctions.smartContrast(textColor, darkenedColor)).toBe(darkenedColor);
     });
   });
 });


### PR DESCRIPTION
This PR adds the smartContrast method to the style-processor's toolkit.

This method is added to fix issues where the contrast of fg and bg colors isn't big enough for people with impaired vision (color blind and more)
We have an open ticket for this here: https://jira.wixpress.com/browse/USERS-2275

Since site colors can be changed by the user, and in some components we have hover states that add some opacity to the background/foreground, this method will give us to help maintain proper a11y.

See corresponding PR in `wix-style-processor`: https://github.com/wix/wix-style-processor/pull/14