### PR TITLE
Add support for webpack v5

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -51,7 +51,7 @@ class TPAStylePlugin {
     const runtimePath = path.resolve(__dirname, '../../runtime.js');
     const nmrp = new webpack.NormalModuleReplacementPlugin(/runtime\.js$/, resource => {
       if (isWebpack5) {
-        // `resource`, `request`, and `loaders` are exposed as `createData`
+        // `resource`, `request`, and `loaders` are exposed under `createData`
         // in webpack v5
         resource = resource.createData;
       }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,4 @@
-import webpackSources from 'webpack-sources';
+import * as webpackSources from 'webpack-sources';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as postcss from 'postcss';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,4 @@
-import {RawSource, ReplaceSource} from 'webpack-sources';
+import webpackSources from 'webpack-sources';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as postcss from 'postcss';
@@ -9,6 +9,11 @@ import {Result} from 'postcss';
 import {createHash} from 'crypto';
 import * as webpack from 'webpack';
 import {generateStandaloneCssConfigFilename} from './standaloneCssConfigFilename';
+
+const isWebpack5 = parseInt(webpack.version, 10) === 5;
+
+// use webpack's `webpack-sources` version, if it's v5, we'll get v2.0.0
+const {RawSource, ReplaceSource} = isWebpack5 ? webpack.source : webpackSources;
 
 class TPAStylePlugin {
   public static pluginName = 'tpa-style-webpack-plugin';
@@ -45,6 +50,12 @@ class TPAStylePlugin {
   private replaceRuntimeModule(compiler) {
     const runtimePath = path.resolve(__dirname, '../../runtime.js');
     const nmrp = new webpack.NormalModuleReplacementPlugin(/runtime\.js$/, resource => {
+      if (isWebpack5) {
+        // `resource`, `request`, and `loaders` are exposed as `createData`
+        // in webpack v5
+        resource = resource.createData;
+      }
+
       if (fs.realpathSync(resource.resource) !== runtimePath) {
         return;
       }


### PR DESCRIPTION
### Summary

This PR adds support for `tpa-style-webpack-plugin` to work well with [webpack v5](https://webpack.js.org/blog/2020-10-10-webpack-5-release/). Because this plugin is being used in many different projects, I think it's best if we can support both v4 and v5 at the same time (even if our test run only against v4). 

I tested this locally with webpack version 5 and I think we should run our test against it and (possibly stop testing against v4) once most projects use webpack v5.
