### PR TITLE
Use the correct name for accessing webpack-sources with webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,7 +13,7 @@ import {generateStandaloneCssConfigFilename} from './standaloneCssConfigFilename
 const isWebpack5 = parseInt(webpack.version, 10) === 5;
 
 // use webpack's `webpack-sources` version, if it's v5, we'll get v2.0.0
-const {RawSource, ReplaceSource} = isWebpack5 ? webpack.source : webpackSources;
+const {RawSource, ReplaceSource} = isWebpack5 ? webpack.sources : webpackSources;
 
 class TPAStylePlugin {
   public static pluginName = 'tpa-style-webpack-plugin';


### PR DESCRIPTION
### Summary

Following https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/19, this PR fixes an issue where I accessed `webpack-sources` (now exported from `webpack`) though the wrong attribute name.

I found this already (while working on the previous PR) and fixed it but I didn't push it apparently.
