### PR TITLE
Smart contrast fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ addStyles(dynamicCss, 'tag-id');
     font: "font(--my-font2)";                                               /* will use the overridden default unless it was defined in settings  */
     border-width: "unit(--var-from-settings, px)";                          /* will produce border-width: 42px */
     color: "fallback(color(--var-from-settings), color(color-8))";          /* will return the first none falsy value from left to right */
-    background-color: "smartContrast(color(--base-color), color(--contrast-color))"; /* given a base color and a suggested contrast color, returns the given contrast color if it's A11Y compliant or a lightened/darkened color that will comply */
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.3.19",
+  "version": "1.4.0",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/src/runtime/cssFunctions.ts
+++ b/src/runtime/cssFunctions.ts
@@ -123,6 +123,11 @@ export const cssFunctions = {
       return numbersWithoutTPAParams[0];
     }
   },
+  readableFallback: (baseColor: string, suggestedColor: string, fallbackColor: string) => {
+    const baseColorTC = new TinyColor(baseColor);
+    const suggestedColorTC = new TinyColor(suggestedColor);
+    return isReadable(baseColorTC, suggestedColorTC) ? suggestedColor : fallbackColor;
+  },
   /**
    * Given foreground and background colors, checks to see if the colors are readable together.
    * If not, it returns the first to be readable among:

--- a/tests/__snapshots__/extract-styles.spec.ts.snap
+++ b/tests/__snapshots__/extract-styles.spec.ts.snap
@@ -114,7 +114,9 @@ exports[`Extract Styles should contain only TPA styles: dynamic-css 1`] = `
  .smart-contrast-bad-light {background-color: rgb(168, 168, 168);}
  .smart-contrast-bad-dark {background-color: rgb(168, 168, 168);}
  .smart-contrast-bad-with-opacity {background-color: rgba(168, 168, 168, 0.7);}
- .smart-contrast-ssr-crash-of-16-12-21 {background-color: rgb(168, 168, 168);}"
+ .smart-contrast-ssr-crash-of-16-12-21 {background-color: rgb(168, 168, 168);}
+ .readable-fallback-good {color: ;}
+ .readable-fallback-bad {color: ;}"
 `;
 
 exports[`Extract Styles should extract out TPA styles from regular css: static-css 1`] = `

--- a/tests/__snapshots__/extract-styles.spec.ts.snap
+++ b/tests/__snapshots__/extract-styles.spec.ts.snap
@@ -109,9 +109,12 @@ exports[`Extract Styles should contain only TPA styles: dynamic-css 1`] = `
  .nested-functions-with-multiple-functions-params {--var: #F3F3F3; color: rgba(255, 255, 255, 0.5)}
  .font-without-font-family {font: italic normal bold 10px/2em futura-lt-w01-book,sans-serif;text-decoration: };
  .font-with-multiple-font-family {font: italic normal bold 10px/2em futura-lt-w01-book,sans-serif;text-decoration: };
- .smart-contrast-good {background-color: rgb(0, 0, 0);}
- .smart-contrast-bad {background-color: rgb(0, 0, 0);}
- .smart-contrast-bad-flipped {background-color: rgb(0, 0, 0);}"
+ .smart-contrast-good-light {background-color: rgb(168, 168, 168);}
+ .smart-contrast-good-dark {background-color: rgb(168, 168, 168);}
+ .smart-contrast-bad-light {background-color: rgb(168, 168, 168);}
+ .smart-contrast-bad-dark {background-color: rgb(168, 168, 168);}
+ .smart-contrast-bad-with-opacity {background-color: rgba(168, 168, 168, 0.7);}
+ .smart-contrast-ssr-crash-of-16-12-21 {background-color: rgb(168, 168, 168);}"
 `;
 
 exports[`Extract Styles should extract out TPA styles from regular css: static-css 1`] = `

--- a/tests/fixtures/styles2.css
+++ b/tests/fixtures/styles2.css
@@ -106,3 +106,7 @@
 .smart-contrast-bad-with-opacity {background-color: "smartBGContrast(opacity(color(--textColor), 0.7), opacity(color(--badDarkBgColor), 0.7))";}
 
 .smart-contrast-ssr-crash-of-16-12-21 {background-color: "smartBGContrast(color(--infiniteLoopFGColor), color(--infiniteLoopBGColor))";}
+
+.readable-fallback-good {color: "readableFallback(color(--baseColor), color(--goodSuggestionColor), color(--fallbackColor))";}
+
+.readable-fallback-bad {color: "readableFallback(color(--baseColor), color(--badSuggestionColor), color(--fallbackColor))";}

--- a/tests/fixtures/styles2.css
+++ b/tests/fixtures/styles2.css
@@ -95,8 +95,14 @@
 
 .font-with-multiple-font-family {font: "font(--bodyText)"};
 
-.smart-contrast-good {background-color: "smartContrast(color(--fgColor), color(--darkenedBGColor))";}
+.smart-contrast-good-light {background-color: "smartBGContrast(color(--textColor), color(--goodLightBgColor))";}
 
-.smart-contrast-bad {background-color: "smartContrast(color(--fgColor), color(--badBGColor))";}
+.smart-contrast-good-dark {background-color: "smartBGContrast(color(--textColor), color(--goodDarkeBgColor))";}
 
-.smart-contrast-bad-flipped {background-color: "smartContrast(color(--badBGColor), color(--fgColor))";}
+.smart-contrast-bad-light {background-color: "smartBGContrast(color(--textColor), color(--badLightBgColor))";}
+
+.smart-contrast-bad-dark {background-color: "smartBGContrast(color(--textColor), color(--badDarkBgColor))";}
+
+.smart-contrast-bad-with-opacity {background-color: "smartBGContrast(opacity(color(--textColor), 0.7), opacity(color(--badDarkBgColor), 0.7))";}
+
+.smart-contrast-ssr-crash-of-16-12-21 {background-color: "smartBGContrast(color(--infiniteLoopFGColor), color(--infiniteLoopBGColor))";}

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -698,6 +698,29 @@ describe('runtime', () => {
     });
   });
 
+  describe('readableFallback', () => {
+    const baseColor = '#ffffff';
+    const goodSuggestionColor = '#333333';
+    const fallbackColor = '#000000';
+    const badSuggestionColor = '#ffff00';
+
+    it('should return a11y compliant colors', () => {
+      const newStyleParams = clonedWith(styleParams, {
+        numbers: {},
+        colors: {
+          baseColor: {value: baseColor},
+          goodSuggestionColor: {value: goodSuggestionColor},
+          fallbackColor: {value: fallbackColor},
+          badSuggestionColor: {value: badSuggestionColor},
+        },
+        fonts: {},
+      });
+      const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {});
+      expect(css).toContain(`.readable-fallback-good {color: ${goodSuggestionColor};}`);
+      expect(css).toContain(`.readable-fallback-bad {color: ${fallbackColor};}`);
+    });
+  });
+
   describe('Options', () => {
     describe('isRTL', () => {
       it('should support LTR', () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -7,6 +7,7 @@ import {siteTextPresets} from './fixtures/siteTextPresets';
 import {styleParams} from './fixtures/styleParams';
 import {clonedWith} from './helpers/cloned-with';
 import {readFile} from './helpers/readfile';
+import {TinyColor} from '@ctrl/tinycolor';
 
 describe('runtime', () => {
   const outputDirPath = path.resolve(__dirname, './output/runtime');
@@ -647,29 +648,53 @@ describe('runtime', () => {
   });
 
   describe('smartContrast', () => {
-    const fgColor = '#DFF0D8';
-    const badBGColor = '#468847';
-    const lightenedFGColor = 'rgb(255, 255, 255)';
-    const darkenedBGColor = 'rgb(61, 119, 62)';
+    const textColor = new TinyColor('hsl(196, 57, 39)').toRgbString(); // some kind of blue
+    const goodLightBgColor = new TinyColor(textColor).lighten(60).toRgbString(); // 'hsl(196, 57, 99)';
+    const goodDarkBgColor = new TinyColor(textColor).darken(40).toRgbString(); // 'hsl(196, 57, 99)';
+    const badLightBgColor = new TinyColor('hsl(196, 57, 60)').toRgbString(); // brighter than textColor
+    const badDarkBgColor = new TinyColor('hsl(196, 57, 35)').toRgbString(); // darker than textColor
+    const fallbackForBadLightColor = new TinyColor(badLightBgColor).lighten(40).toRgbString();
+    const fallbackForBadDarkColor = new TinyColor(badDarkBgColor).darken(40).toRgbString();
 
     it('should return a11y compliant colors', () => {
       const newStyleParams = clonedWith(styleParams, {
         numbers: {},
         colors: {
-          fgColor: {value: fgColor},
-          badBGColor: {value: badBGColor},
-          lightenedFGColor: {value: lightenedFGColor},
-          darkenedBGColor: {value: darkenedBGColor},
+          textColor: {value: textColor},
+          goodLightBgColor: {value: goodLightBgColor},
+          goodDarkBgColor: {value: goodDarkBgColor},
+          badLightBgColor: {value: badLightBgColor},
+          badDarkBgColor: {value: badDarkBgColor},
+          fallbackForBadLightColor: {value: fallbackForBadLightColor},
+          fallbackForBadDarkColor: {value: fallbackForBadDarkColor},
         },
         fonts: {},
       });
       const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {});
-      const acceptGivenGoodColor = `.smart-contrast-good {background-color: ${darkenedBGColor};}`;
-      expect(css).toContain(acceptGivenGoodColor);
-      const adjustGivenBadColor = `.smart-contrast-bad {background-color: ${darkenedBGColor};}`;
-      expect(css).toContain(adjustGivenBadColor);
-      const adjustFlippedColors = `.smart-contrast-bad-flipped {background-color: ${lightenedFGColor};}`;
-      expect(css).toContain(adjustFlippedColors);
+      expect(css).toContain(`.smart-contrast-good-light {background-color: ${goodLightBgColor};}`);
+      expect(css).toContain(`.smart-contrast-good-dark {background-color: ${goodDarkBgColor};}`);
+      expect(css).toContain(`.smart-contrast-bad-light {background-color: ${fallbackForBadLightColor};}`);
+      expect(css).toContain(`.smart-contrast-bad-dark {background-color: ${fallbackForBadDarkColor};}`);
+      expect(css).toContain(
+        `.smart-contrast-bad-with-opacity {background-color: ${new TinyColor(fallbackForBadDarkColor)
+          .setAlpha(0.7)
+          .toRgbString()};}`
+      );
+    });
+
+    it('should not cause an infinite loop', () => {
+      const newStyleParams = clonedWith(styleParams, {
+        numbers: {},
+        colors: {
+          infiniteLoopFGColor: {value: 'rgba(186, 131, 240, 0.7)'},
+          infiniteLoopBGColor: {value: 'rgba(249, 197, 180, 0.7)'},
+        },
+        fonts: {},
+      });
+
+      const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {});
+
+      expect(css).toContain('.smart-contrast-ssr-crash-of-16-12-21 {background-color: rgba(255, 255, 255, 0.7);}');
     });
   });
 

--- a/tests/units/cssFunctions.spec.ts
+++ b/tests/units/cssFunctions.spec.ts
@@ -1,3 +1,4 @@
+import {TinyColor} from '@ctrl/tinycolor';
 import {cssFunctions} from '../../src/runtime/cssFunctions';
 import {IS_RTL_PARAM} from '../../src/runtime/constants';
 import {clonedWith} from '../helpers/cloned-with';
@@ -260,21 +261,38 @@ describe('cssFunctions', () => {
   });
 
   describe('smartContrast', () => {
-    const textColor = '#DFF0D8';
-    const lightenedColor = 'rgb(255, 255, 255)';
-    const badBgColor = '#468847';
-    const darkenedColor = 'rgb(61, 119, 62)';
+    const textColor = 'hsl(196, 57, 39)'; // some kind of blue
+    const goodLightBgColor = new TinyColor(textColor).lighten(60).toHslString(); // 'hsl(196, 57, 99)';
+    const goodDarkBgColor = new TinyColor(textColor).darken(40).toHslString(); // 'hsl(196, 57, 99)';
+    const badLightBgColor = 'hsl(196, 57, 60)'; // brighter than textColor
+    const badDarkBgColor = 'hsl(196, 57, 35)'; // darker than textColor
+    const fallbackForBadLightColor = new TinyColor(badLightBgColor).lighten(40).toRgbString();
+    const fallbackForBadDarkColor = new TinyColor(badDarkBgColor).darken(40).toRgbString();
 
-    it('should return darkened color when contrast to low', () => {
-      expect(cssFunctions.smartContrast(textColor, badBgColor)).toBe(darkenedColor);
+    it('should give fallback for bad contrast - with lightening', () => {
+      expect(cssFunctions.smartBGContrast(textColor, badLightBgColor)).toBe(fallbackForBadLightColor);
     });
 
-    it('should return lightened color when contrast to low', () => {
-      expect(cssFunctions.smartContrast(badBgColor, textColor)).toBe(lightenedColor);
+    it('ignores opacity for the time being', () => {
+      expect(
+        cssFunctions.smartBGContrast(cssFunctions.opacity(textColor, 0.7), cssFunctions.opacity(badLightBgColor, 0.7))
+      ).toBe(cssFunctions.opacity(fallbackForBadLightColor, 0.7));
     });
 
-    it('should return same color when good contrast', () => {
-      expect(cssFunctions.smartContrast(textColor, darkenedColor)).toBe(darkenedColor);
+    it('should give fallback for bad contrast - with darkening', () => {
+      expect(cssFunctions.smartBGContrast(textColor, badDarkBgColor)).toBe(fallbackForBadDarkColor);
+    });
+
+    it('should return bg color if contrast is good - lighter background', () => {
+      expect(cssFunctions.smartBGContrast(textColor, goodLightBgColor)).toBe(
+        new TinyColor(goodLightBgColor).toRgbString()
+      );
+    });
+
+    it('should return bg color if contrast is good - darker background', () => {
+      expect(cssFunctions.smartBGContrast(textColor, goodDarkBgColor)).toBe(
+        new TinyColor(goodDarkBgColor).toRgbString()
+      );
     });
   });
 });

--- a/tests/units/cssFunctions.spec.ts
+++ b/tests/units/cssFunctions.spec.ts
@@ -295,4 +295,19 @@ describe('cssFunctions', () => {
       );
     });
   });
+
+  describe('readableFallback', () => {
+    const baseColor = 'white';
+    const goodSuggestionColor = '#333333';
+    const fallbackColor = 'black';
+    const badSuggestionColor = 'yellow';
+
+    it('should return suggested color if base and suggestion colors are readable together', () => {
+      expect(cssFunctions.readableFallback(baseColor, goodSuggestionColor, fallbackColor)).toBe(goodSuggestionColor);
+    });
+
+    it('should return fallback color if base and suggestion colors are not readable together', () => {
+      expect(cssFunctions.readableFallback(baseColor, badSuggestionColor, fallbackColor)).toBe(fallbackColor);
+    });
+  });
 });


### PR DESCRIPTION
changed implementation + added tests.

Also added the `readableFallback` method, which is much simpler.
Given three colors: a base color, a suggestion color, and a fallback color, it checks if the base and suggestion colors are readable.
If they are, the suggestion color is returned, if not, the fallback is returned.

Also removed README documentation.
I think it might be best to leave it undocumented for now, so that we can first try it in wix-ui-tpa for a while.

Related PR: https://github.com/wix/wix-style-processor/pull/15