### PR TITLE
Use correct escaping for webpack 5 eval's source maps

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -32,7 +32,8 @@ class TPAStylePlugin {
   }
 
   apply(compiler) {
-    const shouldEscapeContent = ['cheap-module-eval-source-map', 'cheap-eval-source-map'].includes(
+    const cheapModuleEvalSourceMap = isWebpack5 ? 'eval-cheap-module-source-map' : 'cheap-module-eval-source-map';
+    const shouldEscapeContent = [cheapModuleEvalSourceMap, 'cheap-eval-source-map'].includes(
       compiler.options.devtool
     );
     this.replaceRuntimeModule(compiler);


### PR DESCRIPTION
### Summary

One of the breaking changes in webpack 5's bump was some [naming changes to the `devtool` configuration](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#changes-to-the-structure). This PR adjusts the plugin to use correct escaping for webpack 5. Currently, this causes syntax errors from improper escaping.

Thanks!
