### PR TITLE
Fix deprecation warnings from webpack 5

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -38,14 +38,14 @@ class TPAStylePlugin {
     );
     this.replaceRuntimeModule(compiler);
 
-    const pluginDescriptor = isWebpack5
-      ? TPAStylePlugin.pluginName
-      : {
-          name: TPAStylePlugin.pluginName,
-          stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
-        };
-
     compiler.hooks.compilation.tap(TPAStylePlugin.pluginName, compilation => {
+      const pluginDescriptor = isWebpack5
+        ? TPAStylePlugin.pluginName
+        : {
+            name: TPAStylePlugin.pluginName,
+            stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+          };
+
       compilation.hooks.processAssets.tapAsync(pluginDescriptor, (chunks, callback) => {
         this.extract(compilation, chunks)
           .then(extractResults => this.replaceSource(compilation, extractResults, shouldEscapeContent))
@@ -83,11 +83,11 @@ class TPAStylePlugin {
   private extract(compilation, chunks) {
     const promises = [];
 
-    const files = isWebpack5 ? [...chunk.files] : chunk.files;
-
     chunks.forEach(chunk => {
+      // webpack 5 turned this from an array to a set
+      const files = isWebpack5 ? [...chunk.files] : chunk.files;
+
       promises.push(
-        // webpack 5 turned this from an array to a set
         ...files
           .filter(fileName => fileName.endsWith('.css'))
           .map(cssFile =>
@@ -154,10 +154,10 @@ class TPAStylePlugin {
   private replaceSource(compilation, extractResults, shouldEscapeContent) {
     const entryMergedChunks = this.getEntryMergedChunks(extractResults);
 
-    const files = isWebpack5 ? [...chunk.files] : chunk.files;
-
     entryMergedChunks.forEach(({chunk, cssVars, customSyntaxStrs, css, staticCss}) => {
       // webpack 5 turned this from an array to a set
+      const files = isWebpack5 ? [...chunk.files] : chunk.files;
+
       files
         .filter(fileName => fileName.endsWith('.js'))
         .forEach(file => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -83,10 +83,12 @@ class TPAStylePlugin {
   private extract(compilation, chunks) {
     const promises = [];
 
+    const files = isWebpack5 ? [...chunk.files] : chunk.files;
+
     chunks.forEach(chunk => {
       promises.push(
         // webpack 5 turned this from an array to a set
-        ...[...chunk.files]
+        ...files
           .filter(fileName => fileName.endsWith('.css'))
           .map(cssFile =>
             postcss([extractStyles(this._options)])
@@ -152,9 +154,11 @@ class TPAStylePlugin {
   private replaceSource(compilation, extractResults, shouldEscapeContent) {
     const entryMergedChunks = this.getEntryMergedChunks(extractResults);
 
+    const files = isWebpack5 ? [...chunk.files] : chunk.files;
+
     entryMergedChunks.forEach(({chunk, cssVars, customSyntaxStrs, css, staticCss}) => {
       // webpack 5 turned this from an array to a set
-      [...chunk.files]
+      files
         .filter(fileName => fileName.endsWith('.js'))
         .forEach(file => {
           const sourceCode = compilation.assets[file].source();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -40,12 +40,12 @@ class TPAStylePlugin {
 
     compiler.hooks.compilation.tap(TPAStylePlugin.pluginName, compilation => {
       const pluginDescriptor = isWebpack5
-        ? TPAStylePlugin.pluginName
-        : {
+        ? {
             name: TPAStylePlugin.pluginName,
             stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
-          };
-      
+          }
+        : TPAStylePlugin.pluginName;
+
       const hook = isWebpack5 ? compilation.hooks.processAssets : compilation.hooks.optimizeChunkAssets;
 
       hook.tapAsync(pluginDescriptor, (chunks, callback) => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -45,8 +45,10 @@ class TPAStylePlugin {
             name: TPAStylePlugin.pluginName,
             stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
           };
+      
+      const hook = isWebpack5 ? compilation.hooks.processAssets : compilation.hooks.optimizeChunkAssets;
 
-      compilation.hooks.processAssets.tapAsync(pluginDescriptor, (chunks, callback) => {
+      hook.tapAsync(pluginDescriptor, (chunks, callback) => {
         this.extract(compilation, chunks)
           .then(extractResults => this.replaceSource(compilation, extractResults, shouldEscapeContent))
           .then(() => callback())


### PR DESCRIPTION
### Summary

Hopefully the final PR to support webpack v5 without any warnings: This PR doesn't change any functionality but adjusts the plugin to webpack 5's deprecation warnings (creates a lot of noise).

