### PR TITLE
Fix webpack 5 issues by using the correct chunks

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,7 +49,9 @@ class TPAStylePlugin {
       const hook = isWebpack5 ? compilation.hooks.processAssets : compilation.hooks.optimizeChunkAssets;
 
       hook.tapAsync(pluginDescriptor, (chunks, callback) => {
-        this.extract(compilation, chunks)
+        const actualChunks = isWebpack5 ? compilation.chunks : chunks;
+
+        this.extract(compilation, actualChunks)
           .then(extractResults => this.replaceSource(compilation, extractResults, shouldEscapeContent))
           .then(() => callback())
           .catch(callback);


### PR DESCRIPTION
### Summary

This is a follow-up PR to #23. It fixes an issue created it the last PR to use the correct chunks in webpack v5. Currently, this causes a crash in webpack v5.

