### PR TITLE
Use consistent compilation hash (webpack v5)

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,10 +25,18 @@ class TPAStylePlugin {
       pattern: [/"\w+\([^"]*\)"/, /START|END|DIR|STARTSIGN|ENDSIGN|DEG\-START|DEG\-END/],
       ...options,
     };
-    const hash = createHash('md5')
-      .update(new Date().getTime().toString())
-      .digest('hex');
+    const hash = this.getCompilationHash();
     this.compilationHash = `__${hash.substr(0, 6)}__`;
+  }
+
+  getCompilationHash() {
+    if (isWebpack5) {
+      return createHash("md5").update(this._options.packageName).digest("hex");
+    }
+
+    return createHash("md5")
+      .update(new Date().getTime().toString())
+      .digest("hex");
   }
 
   apply(compiler) {


### PR DESCRIPTION
### Summary

This PR adds another bug-fix for webpack 5 support. Webpack 5, introduces [persistent file-system cache](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching), and because we're using time-based hashing ([here](https://github.com/wix-incubator/tpa-style-webpack-plugin/blob/db1ea7dec9478a4890b0d3fc63e3e4202076a388/src/lib/index.ts#L29)), using webpack's cache with hashes that change in each build step causes bad results as the sources we try to string-replace have the old hashes and replacing doesn't work.

The solution was to use a consistent content-hash, one that's unique to the package's name (so it doesn't collide with other apps) instead of a time-based one. To support it, I asked the app's name as one of the options. Once merged, I will bump the version and pass this from Yoshi. I'll update the docs with this option once webpack 5 is the common use-case.
