### PR TITLE
Add `cssConfig.defaults` property to the cssConfig bundle

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,12 +8,12 @@ import * as prefixer from 'postcss-prefix-selector';
 import {Result} from 'postcss';
 import {createHash} from 'crypto';
 import * as webpack from 'webpack';
-import {generateStandaloneCssConfigFilename} from './standaloneCssConfigFilename';
+import {generateStandaloneCssConfigFilename, getRelatedStyleParamsFileName} from './standaloneCssConfigFilename';
 
 const isWebpack5 = parseInt(webpack.version, 10) === 5;
 
 // use webpack's `webpack-sources` version, if it's v5, we'll get v2.0.0
-const {RawSource, ReplaceSource} = isWebpack5 ? webpack.sources : webpackSources;
+const {RawSource, ReplaceSource} = isWebpack5 ? (webpack as any).sources : webpackSources;
 
 class TPAStylePlugin {
   public static pluginName = 'tpa-style-webpack-plugin';
@@ -142,6 +142,26 @@ class TPAStylePlugin {
     return escapedContent.substring(1, escapedContent.length - 1);
   }
 
+  private getStyleParamsDefaultsContent(assets: any, fileName: string) {
+    const styleParamsFileName = getRelatedStyleParamsFileName(fileName);
+    const styleParamsFile = assets[styleParamsFileName];
+
+    if (styleParamsFile) {
+      return `(() => {
+        var styleParamsModule = {};
+        var styleParamsExports = {};
+
+        (function(module, exports) {
+          ${styleParamsFile.source()}
+        })(styleParamsModule, styleParamsExports);
+
+        return styleParamsModule.exports && styleParamsModule.exports.default ? styleParamsModule.exports.default : null;  
+      })()`;
+    }
+
+    return null;
+  }
+
   private replaceByPlaceHolder({sourceCode, newSource, shouldEscapeContent, placeholder, params}) {
     const placeHolder = `'${this.compilationHash}${placeholder}'`;
     const placeHolderPos = sourceCode.indexOf(placeHolder);
@@ -155,11 +175,13 @@ class TPAStylePlugin {
     }
   }
 
-  private generateStandaloneCssConfig({shouldEscapeContent, params}) {
+  private generateStandaloneCssConfig({shouldEscapeContent, params, defaults}) {
     const sourceCode = fs.readFileSync(path.join(__dirname, './cssConfigTemplate.js')).toString();
 
     return new RawSource(
-      sourceCode.replace(`'CSS_CONFIG_PLACEHOLDER'`, this.getPlaceholderContent(params, shouldEscapeContent))
+      sourceCode
+        .replace(`'CSS_CONFIG_PLACEHOLDER'`, this.getPlaceholderContent(params, shouldEscapeContent))
+        .replace(`"STYLE_PARAMS_DEFAULTS_PLACEHOLDER"`, defaults)
     );
   }
 
@@ -199,6 +221,7 @@ class TPAStylePlugin {
           });
 
           const cssConfigFilename = generateStandaloneCssConfigFilename(file);
+          const defaults = this.getStyleParamsDefaultsContent(compilation.assets, file);
 
           const params = {
             cssVars,
@@ -206,11 +229,13 @@ class TPAStylePlugin {
             css,
             staticCss,
             compilationHash: this.compilationHash,
+            defaults: 'STYLE_PARAMS_DEFAULTS_PLACEHOLDER',
           };
 
           compilation.assets[cssConfigFilename] = this.generateStandaloneCssConfig({
             shouldEscapeContent,
             params,
+            defaults,
           });
 
           compilation.assets[file] = newSource;

--- a/src/lib/standaloneCssConfigFilename.ts
+++ b/src/lib/standaloneCssConfigFilename.ts
@@ -1,5 +1,5 @@
 export function generateStandaloneCssConfigFilename(fileName: string) {
-  return injectFileNamePart(fileName, 'cssConfig');
+  return appendFileName(fileName, 'cssConfig');
 }
 
 export function getRelatedStyleParamsFileName(fileName: string) {
@@ -9,10 +9,10 @@ export function getRelatedStyleParamsFileName(fileName: string) {
    * https://github.com/wix-private/yoshi/blob/7fd08397f8fb744a6fcceb38defd5afb90e86ba8/packages/yoshi-flow-editor/src/wrappers/stylesParamsWrapping.ts#L18
    * https://github.com/wix-private/yoshi/blob/7fd08397f8fb744a6fcceb38defd5afb90e86ba8/packages/yoshi-flow-editor/src/wrappers/stylesParamsWrapping.ts#L27
    */
-  return injectFileNamePart(fileName, 'stylesParams');
+  return appendFileName(fileName, 'stylesParams');
 }
 
-function injectFileNamePart(fileName: string, injectedString: 'cssConfig' | 'stylesParams') {
+function appendFileName(fileName: string, injectedString: 'cssConfig' | 'stylesParams') {
   const parts = fileName.split('.');
 
   const hasPart = (part: string) => parts.some(x => part === x);

--- a/src/lib/standaloneCssConfigFilename.ts
+++ b/src/lib/standaloneCssConfigFilename.ts
@@ -1,8 +1,22 @@
 export function generateStandaloneCssConfigFilename(fileName: string) {
+  return injectFileNamePart(fileName, 'cssConfig');
+}
+
+export function getRelatedStyleParamsFileName(fileName: string) {
+  /**
+   * this is a file name convention with Yoshi Flow Editor
+   * related:
+   * https://github.com/wix-private/yoshi/blob/7fd08397f8fb744a6fcceb38defd5afb90e86ba8/packages/yoshi-flow-editor/src/wrappers/stylesParamsWrapping.ts#L18
+   * https://github.com/wix-private/yoshi/blob/7fd08397f8fb744a6fcceb38defd5afb90e86ba8/packages/yoshi-flow-editor/src/wrappers/stylesParamsWrapping.ts#L27
+   */
+  return injectFileNamePart(fileName, 'stylesParams');
+}
+
+function injectFileNamePart(fileName: string, injectedString: 'cssConfig' | 'stylesParams') {
   const parts = fileName.split('.');
 
   const hasPart = (part: string) => parts.some(x => part === x);
   const index = [hasPart('js'), hasPart('min'), hasPart('bundle')].filter(x => x).length;
 
-  return [...parts.slice(0, -index), 'cssConfig', ...parts.slice(-index)].join('.');
+  return [...parts.slice(0, -index), injectedString, ...parts.slice(-index)].join('.');
 }

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -20,6 +20,7 @@ export interface CssConfig {
   css: string;
   staticCss: string;
   compilationHash: string;
+  defaults?: string;
 }
 
 const defaultOptions = {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -73,6 +73,8 @@ export interface ITextPreset {
 
 export interface IOptions {
   isRTL: boolean;
+  isMobile: boolean;
+  multilingualLanguage: string;
   prefixSelector: string;
   strictMode: boolean;
 }


### PR DESCRIPTION
Resolves #28 

From now, while webpack run, tpa-style-webpack plugin will inline related `*.styleParams.js` bundle into `defaults` property of cssConfig object.

When related `styleParams.bundle.js` is present, `*.cssConfig.bundle.js` will looks like:
![image](https://user-images.githubusercontent.com/439289/111795479-e8c89780-88cf-11eb-88ca-853cc37de9f4.png)

When there is no related `styleParams.bundle.js`, `*.cssConfig.bundle.js` will looks like:
![image](https://user-images.githubusercontent.com/439289/111793824-4f4cb600-88ce-11eb-8532-5df82587b4db.png)
