### PR TITLE
Add jsChunkPattern and cssChunkPattern options

### DIFF
--- a/tests/customized-chunk-patterns.spec.ts
+++ b/tests/customized-chunk-patterns.spec.ts
@@ -1,0 +1,60 @@
+import * as path from 'path';
+import {clearDir} from './helpers/clear-dir';
+import {runWebpack} from './helpers/run-webpack';
+import {readFile} from './helpers/readfile';
+import {IGetProcessedCssFn} from '../src/runtime/main';
+import {siteColors} from './fixtures/siteColors';
+import {siteTextPresets} from './fixtures/siteTextPresets';
+import {styleParams} from './fixtures/styleParams';
+
+describe('customized-chunk-patterns', () => {
+  const outputDirPath = path.resolve(__dirname, './output/customized-chunk-patterns');
+  const entryName1 = 'app1';
+  const entryName2 = 'app2';
+  let cssFile1,
+    tpaRuntime1: {getProcessedCss: IGetProcessedCssFn},
+    cssFile2,
+    tpaRuntime2: {getProcessedCss: IGetProcessedCssFn};
+
+  beforeAll(async () => {
+    await clearDir(outputDirPath);
+    await runWebpack(
+      {
+        output: {
+          path: path.resolve(outputDirPath),
+          libraryTarget: 'commonjs',
+        },
+        entry: {
+          [entryName1]: './tests/fixtures/first-entry.ts',
+          [entryName2]: './tests/fixtures/first-entry.ts',
+        },
+      },
+      {
+        jsChunkPattern: new RegExp(`${entryName1}\\.bundle\\.js$`),
+        cssChunkPattern: new RegExp(`${entryName1}\\.styles\\.css$`),
+      }
+    );
+
+    cssFile1 = await readFile(path.join(outputDirPath, `${entryName1}.styles.css`), 'utf8');
+    cssFile2 = await readFile(path.join(outputDirPath, `${entryName2}.styles.css`), 'utf8');
+    tpaRuntime1 = require(path.join(outputDirPath, `${entryName1}.bundle.js`));
+    tpaRuntime2 = require(path.join(outputDirPath, `${entryName2}.bundle.js`));
+  });
+
+  it('should generate only matched css chunk without tpa styles', () => {
+    expect(cssFile1).not.toContain('.only-tpa');
+    expect(cssFile1).not.toContain('START');
+    expect(cssFile1).not.toContain('END');
+    expect(cssFile1).not.toContain('DIR');
+
+    expect(cssFile2).toContain('.only-tpa');
+    expect(cssFile2).toContain('START');
+    expect(cssFile2).toContain('END');
+    expect(cssFile2).toContain('DIR');
+  });
+
+  it('matched chunk should have body while other one - not', () => {
+    expect(tpaRuntime1.getProcessedCss({styleParams, siteTextPresets, siteColors})).toContain('body {');
+    expect(tpaRuntime2.getProcessedCss({styleParams, siteTextPresets, siteColors})).not.toContain('body {');
+  });
+});

--- a/tests/helpers/run-webpack.ts
+++ b/tests/helpers/run-webpack.ts
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTPAStylePlugin = require('../../dist/lib/index');
 const merge = require('webpack-merge');
 
-const commonConfig = {
+const getCommonConfig = options => ({
   output: {
     filename: '[name].bundle.js',
   },
@@ -28,12 +28,12 @@ const commonConfig = {
   plugins: [
     new MiniCssExtractPlugin({filename: '[name].styles.css'}),
     new HtmlWebpackPlugin(),
-    new ExtractTPAStylePlugin(),
+    new ExtractTPAStylePlugin(options),
   ],
-};
+});
 
-export async function runWebpack(originalConfig: any) {
-  const config = merge(commonConfig, originalConfig);
+export async function runWebpack(originalConfig: any, tpaStylePluginOptions?: any) {
+  const config = merge(getCommonConfig(tpaStylePluginOptions), originalConfig);
 
   return new Promise((resolve, reject) => {
     webpack(config).run((err, stats) => {


### PR DESCRIPTION
This PR adds an ability to specify the pattern for chunks, which should be processed by the webpack plugin.

There are a lot of cases when we don't want to process the CSS or JS files.
For example, entry for Settings panel or Editor mode bundle.

By specifying `jsChunkPattern` or `cssChunkPattern` we can easily control it from the webpack config.

For example,

`SomeWidgetViewer.bundle.js`
`SomeWidgetViewer.css`
`SomeWidgetEditor.bundle.js`
`SomeWidgetEditor.css`
`otherfile.js`

configuring
```
jsChunkPattern: /Viewer\.bundle\.js$/
cssChunkPattern: /Viewer\.css$/
```

will point wepback plugin to process only the first one.
This configuration will increase the build time.

