### PR TITLE
fix leftovers after defaults was added

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -155,11 +155,11 @@ class TPAStylePlugin {
     const styleParamsFile = assets[styleParamsFileName];
 
     if (styleParamsFile) {
-      return `(() => {
+      return `(function () {
         var styleParamsModule = {};
         var styleParamsExports = {};
 
-        (function(module, exports) {
+        (function (module, exports) {
           ${styleParamsFile.source()}
         })(styleParamsModule, styleParamsExports);
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -74,7 +74,6 @@ export interface ITextPreset {
 export interface IOptions {
   isRTL: boolean;
   isMobile: boolean;
-  multilingualLanguage: string;
   prefixSelector: string;
   strictMode: boolean;
 }


### PR DESCRIPTION
* use es5 syntax for generated code;
* cleanup `multilingualLanguage` from Optioms (will not be used).