### PR TITLE
Add defaults support for getProcessedCss

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,37 @@ addStyles(dynamicCss, 'tag-id');
 
 You can check out an [example project](https://github.com/felixmosh/extract-tpa-style-test).
 
+### Default Values
+
+It's possible to prevent writing `fallback` helper for default values.
+Since you have to maintain the same value in both css and javascript thread, it's much more convenient to have a single source of truth for all default values.
+[TPA-settings](https://github.com/wix-private/tpa-settings) provides a good way to manage defaults.
+By generating a key definitions object, you can use it for both css and js runtimes:
+
+```js
+import {getProcessedCss} from 'tpa-style-webpack-plugin/runtime';
+import {addStyles} from 'tpa-style-webpack-plugin/addStyles';
+import { createStylesParams, StyleParamType } from '@wix/tpa-settings';
+
+const defaults = createStylesParams<{
+  appColor: StyleParamType.Color;
+}>({
+  borderRadius: {
+    type: StyleParamType.Number,
+    getDefaultValue() {
+      return 10;
+    },
+  },
+});
+
+const dynamicCss = getProcessedCss(
+  {styleParams, siteColors, siteTextPresets},
+  {isRTL: false, prefixSelector: '.style-id', strictMode: true},
+  defaults
+);
+addStyles(dynamicCss, 'tag-id');
+```
+
 ## getStaticCss
 
 Use it to inject the static css content to your .js bundle

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/wix-incubator/tpa-style-webpack-plugin",
   "dependencies": {
     "@ctrl/tinycolor": "^2.2.1",
+    "@wix/tpa-settings": "^2.0.260",
     "parse-css-font": "^4.0.0 ",
     "postcss": "^7.0.13",
     "postcss-extract-styles": "^1.2.0",

--- a/src/runtime/generateTPAParams.ts
+++ b/src/runtime/generateTPAParams.ts
@@ -1,8 +1,9 @@
+import {createStyleParamGetter, StyleParamType, IStyles as IStylesStorage} from '@wix/tpa-settings';
 import {pickBy} from './utils/utils';
 import {wixStylesFontUtils} from './utils/wixStyleFontUtils';
 import {wixStylesColorUtils} from './utils/wixStylesColorUtils';
 import {IS_RTL_PARAM} from './constants';
-import {IOptions, ISiteColor, ISiteTextPreset, IStyleFont, IStyleParams} from './types';
+import {IOptions, ISiteColor, ISiteTextPreset, IStyleFont, IStyles, IStyleParams, IDefaults} from './types';
 
 export interface ITPAParams {
   colors: {[index: string]: {value: string}};
@@ -12,19 +13,64 @@ export interface ITPAParams {
   strings: Object;
 }
 
+function overrideStyleParamsWithDefaults(styles: IStyles, defaults: IDefaults | undefined, options: Partial<IOptions>) {
+  if (!defaults) {
+    return styles.styleParams;
+  }
+
+  const getParam = createStyleParamGetter({
+    storage: (styles.styleParams as unknown) as IStylesStorage,
+    colors: styles.siteColors,
+    textPresets: styles.siteTextPresets,
+    isRTL: options.isRTL,
+    isMobile: options.isMobile,
+  });
+
+  const styleParamsMap = {
+    [StyleParamType.Number]: styles.styleParams.numbers,
+    [StyleParamType.Boolean]: styles.styleParams.booleans,
+    [StyleParamType.Font]: styles.styleParams.fonts,
+    [StyleParamType.Color]: styles.styleParams.colors,
+  };
+
+  Object.keys(defaults).forEach(styleKey => {
+    const styleParam = defaults[styleKey];
+    // tslint:disable-next-line:deprecation
+    const keyWithoutTraits = styleParam.key || styleParam.name;
+    const value = getParam(styleParam);
+    if (value && keyWithoutTraits) {
+      const targetStylesMap = styleParamsMap[styleParam.type];
+      targetStylesMap[keyWithoutTraits] = value;
+    }
+  });
+
+  return styles.styleParams;
+}
+
 export function generateTPAParams(
   siteColors: ISiteColor[],
   siteTextPresets: ISiteTextPreset,
   styleParams: IStyleParams,
-  options: Partial<IOptions>
+  options: Partial<IOptions>,
+  defaults: IDefaults
 ): ITPAParams {
-  const colorStyles = styleParams.colors;
-  const fontStyles = pickBy<IStyleFont>(styleParams.fonts, wixStylesFontUtils.isValidFontParam);
+  const styleParamsWithDefaults = overrideStyleParamsWithDefaults(
+    {
+      styleParams,
+      siteColors,
+      siteTextPresets,
+    },
+    defaults,
+    options
+  );
 
-  const numbers = styleParams.numbers || {};
+  const colorStyles = styleParamsWithDefaults.colors;
+  const fontStyles = pickBy<IStyleFont>(styleParamsWithDefaults.fonts, wixStylesFontUtils.isValidFontParam);
+
+  const numbers = styleParamsWithDefaults.numbers || {};
   const colors = wixStylesColorUtils.getFullColorStyles({colorStyles, siteColors}) || {};
   const fonts = wixStylesFontUtils.getFullFontStyles({fontStyles, siteTextPresets}) || {};
-  const strings = pickBy(styleParams.fonts, wixStylesFontUtils.isStringHack);
-  const booleans = {...styleParams.booleans, [IS_RTL_PARAM]: options.isRTL};
+  const strings = pickBy(styleParamsWithDefaults.fonts, wixStylesFontUtils.isStringHack);
+  const booleans = {...styleParamsWithDefaults.booleans, [IS_RTL_PARAM]: options.isRTL};
   return {colors, fonts, numbers, strings, booleans};
 }

--- a/src/runtime/main.ts
+++ b/src/runtime/main.ts
@@ -1,12 +1,13 @@
-import {IOptions, IInjectedData, IStyles} from './types';
+import {IOptions, IInjectedData, IStyles, IDefaults} from './types';
 import {getProcessedCssWithConfig, getStaticCssWithConfig} from './standalone';
 export type IGetProcessedCssFn = typeof getProcessedCss;
 export type IGetStaticCssFn = typeof getStaticCss;
 
-export function getProcessedCss(styles: IStyles, options?: Partial<IOptions>): string {
+export function getProcessedCss(styles: IStyles, options?: Partial<IOptions>, defaults?: IDefaults): string {
   const injectedData = '__COMPILATION_HASH__INJECTED_DATA_PLACEHOLDER' as any;
 
   const processedCssConfig = {
+    defaults,
     ...injectedData,
     compilationHash: '__COMPILATION_HASH__',
   };

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -2,7 +2,7 @@ import {generateTPAParams} from './generateTPAParams';
 import {getProcessor} from './processor';
 import {cssFunctions} from './cssFunctions';
 import {Plugins} from './plugins';
-import {IOptions, IStyles} from './types';
+import {IOptions, IStyles, IDefaults} from './types';
 
 function escapeRegExp(str: string) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
@@ -20,11 +20,12 @@ export interface CssConfig {
   css: string;
   staticCss: string;
   compilationHash: string;
-  defaults?: string;
+  defaults?: IDefaults;
 }
 
 const defaultOptions = {
   isRTL: false,
+  isMobile: false,
   strictMode: true,
 };
 
@@ -44,7 +45,7 @@ export function getProcessedCssWithConfig(
     options.prefixSelector ? `${options.prefixSelector}` : ''
   );
 
-  const tpaParams = generateTPAParams(siteColors, siteTextPresets, styleParams, options);
+  const tpaParams = generateTPAParams(siteColors, siteTextPresets, styleParams, options, processedCssConfig.defaults);
 
   const processor = getProcessor({cssVars: processedCssConfig.cssVars, plugins});
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -78,3 +78,5 @@ export interface IOptions {
   prefixSelector: string;
   strictMode: boolean;
 }
+
+export {IStyleParams as IDefaults} from '@wix/tpa-settings';

--- a/tests/fixtures/runtime-entry-defaults.ts
+++ b/tests/fixtures/runtime-entry-defaults.ts
@@ -1,0 +1,4 @@
+import './styles.css';
+import './styles3.css';
+
+export {getProcessedCss, getStaticCss, getProcessedCssWithConfig, getStaticCssWithConfig} from '../../runtime';

--- a/tests/fixtures/styleKeyDefinitions.ts
+++ b/tests/fixtures/styleKeyDefinitions.ts
@@ -1,0 +1,23 @@
+import {createStylesParams, StyleParamType, wixColorParam, wixFontParam} from '@wix/tpa-settings';
+
+// key definitions with defaults
+export const stylesKeyDefinitions = createStylesParams<{
+  backgroundColor: StyleParamType.Color;
+  borderRadius: StyleParamType.Number;
+  textFont: StyleParamType.Font;
+}>({
+  borderRadius: {
+    type: StyleParamType.Number,
+    getDefaultValue() {
+      return 10;
+    },
+  },
+  backgroundColor: {
+    type: StyleParamType.Color,
+    getDefaultValue: wixColorParam('color-3'),
+  },
+  textFont: {
+    type: StyleParamType.Font,
+    getDefaultValue: wixFontParam('Body-L'),
+  },
+});

--- a/tests/fixtures/styles3.css
+++ b/tests/fixtures/styles3.css
@@ -1,0 +1,7 @@
+.defaults-number {width: "number(--borderRadius)";}
+
+.defaults-fallback-number {width: "fallback(--borderRadius, number(5))";}
+
+.defaults-color {color: "color(--backgroundColor)";}
+
+.defaults-font {font: "font(--textFont)";}

--- a/tests/runtime-size.spec.ts
+++ b/tests/runtime-size.spec.ts
@@ -10,14 +10,14 @@ describe('runtime size', () => {
     await clearDir(outputDirPath);
   });
 
-  it('should throw when lib size exceeds 30kb', () => {
+  it('should throw when lib size exceeds 29.5kb', () => {
     return runWebpack({
       output: {
         path: path.resolve(outputDirPath),
         libraryTarget: 'commonjs',
       },
       performance: {
-        maxEntrypointSize: 30 * 1024,
+        maxEntrypointSize: 29.5 * 1024,
         hints: 'error',
       },
       mode: 'production',

--- a/tests/runtime-size.spec.ts
+++ b/tests/runtime-size.spec.ts
@@ -10,14 +10,14 @@ describe('runtime size', () => {
     await clearDir(outputDirPath);
   });
 
-  it('should throw when lib size exceeds 27kb', () => {
+  it('should throw when lib size exceeds 30kb', () => {
     return runWebpack({
       output: {
         path: path.resolve(outputDirPath),
         libraryTarget: 'commonjs',
       },
       performance: {
-        maxEntrypointSize: 27 * 1024,
+        maxEntrypointSize: 30 * 1024,
         hints: 'error',
       },
       mode: 'production',

--- a/tests/runtime-with-defaults.spec.ts
+++ b/tests/runtime-with-defaults.spec.ts
@@ -8,7 +8,6 @@ import {siteTextPresets} from './fixtures/siteTextPresets';
 import {styleParams} from './fixtures/styleParams';
 import {clonedWith} from './helpers/cloned-with';
 import {readFile} from './helpers/readfile';
-import {TinyColor} from '@ctrl/tinycolor';
 
 describe('runtime with defaults', () => {
   const outputDirPath = path.resolve(__dirname, './output/runtime-with-defaults');

--- a/tests/runtime-with-defaults.spec.ts
+++ b/tests/runtime-with-defaults.spec.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+import {clearDir} from './helpers/clear-dir';
+import {runWebpack} from './helpers/run-webpack';
+import {IGetProcessedCssFn} from '../src/runtime/main';
+import {siteColors, getSiteColor} from './fixtures/siteColors';
+import {stylesKeyDefinitions} from './fixtures/styleKeyDefinitions';
+import {siteTextPresets} from './fixtures/siteTextPresets';
+import {styleParams} from './fixtures/styleParams';
+import {clonedWith} from './helpers/cloned-with';
+import {readFile} from './helpers/readfile';
+import {TinyColor} from '@ctrl/tinycolor';
+
+describe('runtime with defaults', () => {
+  const outputDirPath = path.resolve(__dirname, './output/runtime');
+  const entryName = 'app';
+  let getProcessedCss: IGetProcessedCssFn, runtimeBundleStr: string;
+
+  beforeAll(async () => {
+    await clearDir(outputDirPath);
+    await runWebpack({
+      output: {
+        path: path.resolve(outputDirPath),
+        libraryTarget: 'commonjs',
+      },
+      entry: {
+        [entryName]: './tests/fixtures/runtime-entry-defaults.ts',
+      },
+    });
+
+    const {getProcessedCss: realFunc} = require(path.join(outputDirPath, `${entryName}.bundle.js`));
+    runtimeBundleStr = await readFile(path.join(outputDirPath, `${entryName}.bundle.js`), 'utf8');
+    getProcessedCss = realFunc;
+  });
+
+  it('should support defaults for numbers', () => {
+    const newStyleParams = clonedWith(styleParams, {});
+    const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {}, stylesKeyDefinitions);
+    const expectedCss = '.defaults-number {width: 10;}';
+    expect(css).toContain(expectedCss);
+  });
+
+  it('should support defaults for numbers with a fallback', () => {
+    const newStyleParams = clonedWith(styleParams, {});
+    const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {}, stylesKeyDefinitions);
+    const expectedCss = '.defaults-fallback-number {width: 10;}';
+    expect(css).toContain(expectedCss);
+  });
+
+  it('should support defaults for colors', () => {
+    const newStyleParams = clonedWith(styleParams, {});
+    const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {}, stylesKeyDefinitions);
+    const expectedCss = '.defaults-color {color: rgb(170, 168, 168);}';
+    expect(css).toContain(expectedCss);
+  });
+
+  it('should support defaults for fonts', () => {
+    const newStyleParams = clonedWith(styleParams, {});
+    const css = getProcessedCss({styleParams: newStyleParams, siteColors, siteTextPresets}, {}, stylesKeyDefinitions);
+    const expectedCss = '.defaults-font {font: italic normal bold 20px/1.4em raleway;text-decoration: ;}';
+    expect(css).toContain(expectedCss);
+  });
+});

--- a/tests/runtime-with-defaults.spec.ts
+++ b/tests/runtime-with-defaults.spec.ts
@@ -11,7 +11,7 @@ import {readFile} from './helpers/readfile';
 import {TinyColor} from '@ctrl/tinycolor';
 
 describe('runtime with defaults', () => {
-  const outputDirPath = path.resolve(__dirname, './output/runtime');
+  const outputDirPath = path.resolve(__dirname, './output/runtime-with-defaults');
   const entryName = 'app';
   let getProcessedCss: IGetProcessedCssFn, runtimeBundleStr: string;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "sourceMap": false,
+    "skipLibCheck": true,
     "lib": ["es2015", "es2017"]
   },
   "references": [


### PR DESCRIPTION
This PR brings a way to pass defaults to `getProcessedCss` function.

This is a follow-up for https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/31 giving a way to apply these defaults and use them for CSR also. So we'll have a single source of truth and finally can get rid of fallbakcs.

The only API change is `getProcessedCSS` will accept the __optional third argument__ - `defaults`.
As a result - we can update `withStyles` HOC and pass it here. (I'm going to open PR right after this one will be merged).

If user want to use defaults, the API will looks like:
```js
import {getProcessedCss} from 'tpa-style-webpack-plugin/runtime';
import {addStyles} from 'tpa-style-webpack-plugin/addStyles';
import { createStylesParams, StyleParamType } from '@wix/tpa-settings';
// key definitions with defaults
const defaults = createStylesParams<{
  borderRadius: StyleParamType.Number;
}>({
  borderRadius: {
    type: StyleParamType.Number,
    getDefaultValue() {
      return 10;
    },
  },
});
// passing key definitions
const dynamicCss = getProcessedCss(
  {styleParams, siteColors, siteTextPresets},
  {isRTL: false, prefixSelector: '.style-id', strictMode: true},
  defaults
);
addStyles(dynamicCss, 'tag-id');
```