### PR TITLE
Generate a deterministic `compilationHash`, even on webpack v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -38,7 +38,7 @@ class TPAStylePlugin {
   }
 
   getCompilationHash() {
-    if (isWebpack5) {
+    if (isWebpack5 || this._options.packageName) {
       return createHash('md5')
         .update(this._options.packageName)
         .digest('hex');


### PR DESCRIPTION
### Summary

In a [previous PR](https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/26) we created a consistent compilation hash. Back then, it was important for webpack 5's cache to have deterministic compilations.

This PR also adds this option as a backward compatible option for Yoshi 4. This is important, since now that we create a separate server compilation, the CSS generate in the server compilation needs to match the CSS hashes that have been generated on the client bundle.

In Yoshi 5, we always create deterministic ones (webpack v5), along-side this PR, I will create a PR in Yoshi to pass the `packageName` option. I added a check to use the old behavior if in wasn't passed so older versions of Yoshi won't break if we accidentally bump the version of `tpa-style-webpack-plugin`.
