### PR TITLE
fix: pin version of postcss-prefix-selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "parse-css-font": "^4.0.0 ",
     "postcss": "^7.0.13",
     "postcss-extract-styles": "^1.2.0",
-    "postcss-prefix-selector": "^1.6.0",
+    "postcss-prefix-selector": "1.9.0",
     "webpack-sources": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[Looks like](https://github.com/RadValentin/postcss-prefix-selector/blob/master/package.json#L14) in `postcss-prefix-selector@1.10.0` they bumped required version of `postcss` from 7 to 8.