### PR TITLE
fix: unpin the version of `postcss-prefix-selector`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpa-style-webpack-plugin",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "A Webpack plugin that handles wix tpa styles, it separates static css file that injects dynamic style at runtime.",
   "main": "dist/lib/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "parse-css-font": "^4.0.0 ",
     "postcss": "^7.0.13",
     "postcss-extract-styles": "^1.2.0",
-    "postcss-prefix-selector": "1.9.0",
+    "postcss-prefix-selector": "^1.12.0",
     "webpack-sources": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
after we pin the version in https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/42

new version (with revert of incompatible change) for postcss-prefix-selector was released: v1.12.0