### PR TITLE
Upgrade to `postcss@8`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   "dependencies": {
     "@ctrl/tinycolor": "^2.2.1",
     "parse-css-font": "^4.0.0 ",
-    "postcss": "^7.0.13",
-    "postcss-extract-styles": "^1.2.0",
+    "postcss": "^8.0.0",
     "postcss-prefix-selector": "^1.12.0",
     "webpack-sources": "^1.3.0"
   },

--- a/src/lib/postcssExtractStyles.ts
+++ b/src/lib/postcssExtractStyles.ts
@@ -1,0 +1,68 @@
+export const extractStylesPlugin = opts => {
+  return {
+    postcssPlugin: 'postcss-extract-styles',
+    Once: (css, { result, postcss }) => {
+      opts.pattern = [].concat(opts.pattern || []);
+
+      const extractedCSS = postcss.root();
+      extractStyles(css, extractedCSS, opts);
+
+      result.root = css;
+      result.messages.push({
+        plugin: 'postcss-extract-styles',
+        extracted: extractedCSS,
+      })
+    },
+  };
+};
+
+function extractStyles(css, newcss, opts) {
+  css.each(rule => {
+    if (rule.type === 'atrule' && rule.walkRules && rule.nodes) {
+      const newAtRule = cloneRule(rule);
+
+      extractStyles(rule, newAtRule, opts);
+      appendIfNotEmpty(newAtRule, newcss);
+      removeIfEmpty(rule);
+    } else if (rule.type === 'rule' && rule.walkDecls) {
+      const newRule = cloneRule(rule);
+
+      extractFromDeclarations(rule, newRule, opts);
+      appendIfNotEmpty(newRule, newcss);
+    }
+  });
+}
+
+function extractFromDeclarations(rule, newRule, options) {
+  rule.walkDecls(decl => {
+    const shouldExtractDecl = options.pattern.some(p => p.test(decl.toString()));
+    if (shouldExtractDecl) {
+      const newDecl = decl.clone();
+      newDecl.raws = decl.raws;
+      newRule.append(newDecl);
+
+      decl.remove();
+      removeIfEmpty(rule);
+    }
+  });
+}
+
+function cloneRule(rule) {
+  const newRule = rule.clone();
+
+  newRule.removeAll();
+
+  return newRule;
+}
+
+function appendIfNotEmpty(rule, newcss) {
+  if (rule.nodes.length) {
+    newcss.append(rule);
+  }
+}
+
+function removeIfEmpty(rule) {
+  if (rule.nodes.length === 0) {
+    rule.remove();
+  }
+}


### PR DESCRIPTION
- Use `postcss@8`.
- Migrate internal postcss plugin to `postcss@8`.
- Move `postcss-extract-styles` to this repo as it's not maintained. Migrated to `postcss@8` (started using the [messages api](https://postcss.org/api/#result-messages) in order to get the extracted css from the result, otherwise it's just omitted). We might want to make a fork for this one.